### PR TITLE
Document hard-wrap constraint for blog posts

### DIFF
--- a/.claude/skills/new-blog-post/SKILL.md
+++ b/.claude/skills/new-blog-post/SKILL.md
@@ -26,6 +26,20 @@ This is the most important constraint. The author's style is the product.
 Study existing posts in `source/_posts/` (e.g. `why-i-blog.md`, `short.md`,
 `rlwrap.md`) to internalize the voice before editing.
 
+## No hard wraps
+
+Do **not** introduce hard line breaks inside paragraphs. Write each paragraph
+as one continuous line and let the editor/renderer soft-wrap it. Specifically:
+
+- Never wrap prose at 80, 100, or any other column width.
+- A newline inside a paragraph means "end of paragraph" — only use it where the
+  author intended a paragraph break.
+- If the author's raw input contains hard wraps (e.g. pasted from a wrapped
+  editor), unwrap them: join the lines back into single-line paragraphs,
+  preserving blank lines between paragraphs.
+- This applies to the body, suggestions you present, and anything else you
+  write into `source/_posts/`.
+
 ## Post structure
 
 The author's preferred structure:


### PR DESCRIPTION
## Summary
Added documentation to the blog post skill guide clarifying the hard-wrap constraint: paragraphs must be written as single continuous lines without manual line breaks at arbitrary column widths.

## Changes
- Added a new "No hard wraps" section to `.claude/skills/new-blog-post/SKILL.md` that explicitly prohibits introducing hard line breaks inside paragraphs
- Clarified that newlines should only appear between paragraphs, not within them
- Documented the requirement to unwrap hard-wrapped input (e.g., from pasted text) back into single-line paragraphs
- Specified that this constraint applies to post body content, suggestions presented to the author, and anything written to `source/_posts/`

## Details
This constraint ensures consistency with the author's preferred formatting style and allows the editor/renderer to handle soft-wrapping based on the display context, rather than being locked into a specific column width in the source markdown.

https://claude.ai/code/session_01TDKNkVD4BFgtEAUnhrfDqB