### PR TITLE
Discontinue shipped page and update homepage links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ description: >
 
   ❤️‍🔥 I have a deep passion for developer tools, infra, [Go](https://go.dev), books, blogs, research papers, skateboarding, and your CI setup.<br />
 
-  🔗 Some misc hyperlinks: 🚢 [things I shipped](/shipped), 🗨️ [quotes collection](/quotes), and 📚 [stack of books](/books).<br />
+  🔗 Some misc hyperlinks: 🗨️ [quotes collection](/quotes) and 📚 [stack of books](/books).<br />
 
   👯 Let's connect on <a href="mailto:vishnubharathi04@gmail.com"><i class="fas fa-envelope"></i></a>, [X](https://twitter.com/scriptnull), [🦋](https://bsky.app/profile/vishnubharathi.codes), <a href="https://github.com/scriptnull"><i class="fab fa-github"></i></a>, and <a href="https://linkedin.com/in/scriptnull"><i class="fab fa-linkedin"></i></a>.
 keywords:

--- a/source/shipped/index.md
+++ b/source/shipped/index.md
@@ -1,3 +1,5 @@
+> **Note:** This page is discontinued. Keeping it updated every week became a bit of a hassle, so I have stopped. Leaving whatever was written here as an archive.
+
 (Wish I started this page earlier. Now, I have to reconcile my years of work - lol)
 
 Legend:


### PR DESCRIPTION
## Summary
Removed the "shipped" page link from the homepage and added a deprecation notice to the shipped page itself, as maintaining a weekly updated list became unsustainable.

## Changes
- **`_config.yml`**: Removed the 🚢 [things I shipped](/shipped) link from the homepage description, keeping only the quotes and books links
- **`source/shipped/index.md`**: Added a deprecation notice at the top explaining that the page is no longer maintained, while preserving the existing content as an archive

## Notes
The shipped page remains accessible at its URL for historical reference, but is no longer promoted on the homepage. This reduces maintenance burden while keeping the archived content available.

https://claude.ai/code/session_016VvwvNgvxoJaGr1crospQu