### PR TITLE
Remove two books from the books page

### DIFF
--- a/source/books/index.html
+++ b/source/books/index.html
@@ -602,13 +602,6 @@ date: 2018-09-22 03:40:42
 </div>
 
 <div class="book">
-<blockquote><p>The Art of Laziness</p></blockquote>
-<p>By: Library Mindset</p>
-<p>Tags: productivity</p>
-<hr>
-</div>
-
-<div class="book">
 <blockquote><p>Mindset</p></blockquote>
 <p>By: Dr. Carol S. Dweck</p>
 <p>Tags: mind</p>
@@ -674,13 +667,6 @@ date: 2018-09-22 03:40:42
 <div class="book">
 <blockquote><p>Self-Led</p></blockquote>
 <p>By: Seth Kopald</p>
-<p>Tags: mind</p>
-<hr>
-</div>
-
-<div class="book">
-<blockquote><p>Changing for Good</p></blockquote>
-<p>By: Prochaska, Norcross &amp; DiClemente</p>
 <p>Tags: mind</p>
 <hr>
 </div>


### PR DESCRIPTION
Remove two book entries from the books page that are no longer part of the curated collection.

**Changes:**
- Removed "The Art of Laziness" by Library Mindset (tagged: productivity)
- Removed "Changing for Good" by Prochaska, Norcross & DiClemente (tagged: mind)

These entries were deleted from `source/books/index.html` to keep the books list current and relevant.

https://claude.ai/code/session_013C3uX6TUiUJVCNGAgciMdU