### PR TITLE
Add quote by Reiser and Umemoto to quotes page

### DIFF
--- a/source/quotes/index.md
+++ b/source/quotes/index.md
@@ -7,6 +7,14 @@ Some words that inspire and help me.
 
 ---
 
+> in a moving world the nomad is the one standing still
+
+By: Reiser and Umemoto
+
+Source: The Atlas of Novel Tectonics, via [Hacker News](https://news.ycombinator.com/item?id=49119484)
+
+---
+
 > Your duty is to uphold dharma. You have a right to perform your prescribed action, but you are not entitled to the fruits of your action. Never consider yourself to be the cause of the results of your activities, and never be attached to not doing your duty.
 
 By: Lord Krishna


### PR DESCRIPTION
Adds a new quote to the quotes collection on the personal website.

## Changes
- Added a new quote: "in a moving world the nomad is the one standing still" by Reiser and Umemoto
- Sourced from *The Atlas of Novel Tectonics* via Hacker News
- Placed at the top of the quotes list, following the convention of newest-first ordering

## Notes
This change requires a `[deploy]` prefix on the commit message to be published via CI.

https://claude.ai/code/session_01UriXVitQVXRWvmfm8LGhwC