### PR TITLE
[deploy] add blog post: Reading Log #1

### DIFF
--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -1,5 +1,5 @@
 ---
-title: Reading Log #1
+title: "Reading Log #1"
 date: 2026-08-02 01:20:00
 tags: ["reading", "books", "blogging"]
 ---

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -1,12 +1,12 @@
 ---
 title: "Reading Log #1"
 date: 2026-08-02 01:20:00
-tags: ["reading", "books", "blogging"]
+tags: ["reading", "books", "blogs"]
 ---
 
-I used to use [Feedly](https://feedly.com/) for a long time for keeping up with my favorite blogs. But then I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time for the past 6 months. It is in a weird shape but definitely distracted myself from doing the real reading that I enjoy.
+I used to use [Feedly](https://feedly.com/) for a long time to keep up to date with my favorite blogs. Six months back, one fine day, I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time. It went somewhere but my reading time went down. Sadly my reader didn't work out - it has hindered my reading and now I am out here resuming my reading.
 
-I have mashed up a new blog reading system for me but not based on my reader. Sadly it is not working out and I have to give up to get back to reading. Maybe I will talk about the new system some other time after experimenting with it for a bit.
+So I have mashed up a new blog reading system for me but not based on my reader. Maybe I will talk about the new system some other time after experimenting with it for a bit.
 
 But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 2026.
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -4,7 +4,7 @@ date: 2026-08-02 01:20:00
 tags: ["reading", "books", "blogging"]
 ---
 
-I am trying something new. I used to use [Feedly](https://feedly.com/) for a long time for keeping up with my favorite blogs. But then I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time for the past 6 months. It is in a weird shape but definitely distracted myself from doing the real reading that I enjoy.
+I used to use [Feedly](https://feedly.com/) for a long time for keeping up with my favorite blogs. But then I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time for the past 6 months. It is in a weird shape but definitely distracted myself from doing the real reading that I enjoy.
 
 I have mashed up a new blog reading system for me but not based on my reader. Sadly it is not working out and I have to give it up. Maybe I will talk about the new system some other time after experimenting it for a bit.
 
@@ -14,21 +14,15 @@ But for now, here is what I read in the week of 27 to 31 July 2026.
 
 - [AI Made Me Braver](https://neilkakkar.com/ai-made-me-braver.html) by Neil Kakkar
 
-  There is a DOCX to DOCX converter, wait what? One is Google Docs DOCX, and another is my DOCX.
-
-  I like this quote:
-
-  > Looking back, being productive is nice. But imo feeling braver matters more.
+  There is a DOCX to DOCX converter, wait what?
 
 - [How I get things done](https://mxstbr.com/notes/getting-things-done) by Max Stoiber
 
-  RACI vs ARCI & DRI.
+  I have come across RACI/ARCI & DRI at work before. I still feel like it is "too much theory" but the author gets to the practicality of it i.e. "Assign one accountable owner" is a distillation that I like to remember from this post.
 
 - [The AI Productivity Gap](https://bjorg.bjornroche.com/management/ai-productivity-gap/) by Bjorn Roche
 
-  Love multiple takes in this one.
-
-  I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts.
+  Love multiple takes in this one. I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts.
 
   > Using AI to make your work easier while making other people's job harder
 
@@ -36,13 +30,7 @@ But for now, here is what I read in the week of 27 to 31 July 2026.
 
 - [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon) by Tim Bray
 
-  Rekindled my interest in Mastodon and to get serious about it.
-
-  I have been using all the others (X, bsky) but stopped using Mastodon, mostly I think I was confused to what is the place I want to use for short form blogging.
-
-  Based on this blog post and my own experiences in the past few months, I clearly need to try Mastodon now.
-
-  I spent much time exploring Mastodon. Still not so clear with it. e.g. which server?
+  Rekindled my interest in Mastodon. I have been using all the others (X, bsky) but stopped using Mastodon, mostly I think I was confused to what is the place I want to use for short form blogging.
 
 - [Generated and suppressed demand](https://lethain.com/generated-demand/) by Will Larson
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -30,7 +30,7 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
   > Using AI to make your work easier while making other people's job harder
 
-  My take: As we use AI more and more in a team setting, we need to be very thoughtful and mindful in producing artifacts that doesn't overload our colleagues.
+  My take: As we use AI more and more in a team setting, we need to be very thoughtful and mindful in producing artifacts that don't overload our colleagues.
 
 - [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon)
 
@@ -76,11 +76,15 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
 ## Books
 
-- **Rework** - 82 pages
+- **Rework**
+
+  82 pages read
 
   I haven't been taking notes for this one. Because it is the kind of a book that you could re-read instead of reading your notes.
 
-- **Let Go** - 38 pages
+- **Let Go**
+
+  38 pages read
 
   My wife picked up this book from the book store. I randomly started reading on a weekday night. I could visibly feel my "stress level" going down page after page. wow, books are weird - they can alter space, time, and mind.
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -78,5 +78,9 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
 - **Rework** - 82 pages
 
+  TK - thoughts on Rework. Journal hook from the same week: you listened to DHH on the David Senra show and wrote "he really cares that his day is within his control. I think that is what I should aspire for right now."
+
 - **Let Go** - 38 pages
+
+  TK - thoughts on Let Go. Journal hook: "Great set of learning." Also still missing the author/link for this one.
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -6,7 +6,7 @@ tags: ["reading", "books", "blogging"]
 
 I used to use [Feedly](https://feedly.com/) for a long time to keep up to date with my favorite blogs. Six months back, one fine day, I started working on my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time. It went somewhere but my reading time went down. Sadly my reader didn't work out - it has hindered my reading and now I am out here resuming my reading.
 
-So I have mashed up a new blog reading system for me but not based on my reader. Maybe I will talk about the new system some other time after experimenting with it for a bit.
+I have mashed up a new blog reading system for me but not based on my reader. Maybe I will talk about the new system some other time after experimenting with it for a bit.
 
 But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 2026.
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -6,7 +6,9 @@ tags: ["reading", "books", "blogging"]
 
 I am trying something new. I used to use [Feedly](https://feedly.com/) for a long time for keeping up with my favorite blogs. But then I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time for the past 6 months. It is in a weird shape but definitely distracted myself from doing the real reading that I enjoy.
 
-This is what I read in the week of 27 July to 31 July 2026.
+I have mashed up a new blog reading system for me but not based on my reader. Sadly it is not working out and I have to give it up. Maybe I will talk about the new system some other time after experimenting it for a bit.
+
+But for now, here is what I read in the week of 27 to 31 July 2026.
 
 ## Blogs
 
@@ -96,10 +98,5 @@ This is what I read in the week of 27 July to 31 July 2026.
 
 - **Rework** - pages 1-32 on Sunday, 32-42 on Monday, 32-66 and then 67-82 on Tuesday.
 
-  TK
-
 - **Let Go** - pages 77-115 on Tuesday.
 
-  Great set of learning.
-
-  TK - author/link for this one.

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -78,9 +78,9 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
 - **Rework** - 82 pages
 
-  TK - thoughts on Rework. Journal hook from the same week: you listened to DHH on the David Senra show and wrote "he really cares that his day is within his control. I think that is what I should aspire for right now."
+  I haven't been taking notes for this one. Because it is the kind of a book that you could re-read instead of reading your notes.
 
 - **Let Go** - 38 pages
 
-  TK - thoughts on Let Go. Journal hook: "Great set of learning." Also still missing the author/link for this one.
+  My wife picked up this book from the book store. I randomly started reading on a weekday night. I could visibly feel my "stress level" going down page after page. wow, books are weird - they can alter space, time, and mind.
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -14,98 +14,96 @@ This is the week of 27 July to 31 July 2026.
 
 ## Books
 
-### Rework
+- **Rework** - pages 1-32 on Sunday, 32-42 on Monday, 32-66 and then 67-82 on Tuesday.
 
-Pages 1-32 on Sunday, 32-42 on Monday, 32-66 and then 67-82 on Tuesday.
+  TK
 
-TK
+- **Let Go** - pages 77-115 on Tuesday.
 
-### Let Go
+  Great set of learning.
 
-Pages 77-115 on Tuesday. Great set of learning.
-
-TK - author/link for this one.
+  TK - author/link for this one.
 
 ## Blogs
 
-### [AI Made Me Braver](https://neilkakkar.com/ai-made-me-braver.html) - Neil Kakkar
+- [AI Made Me Braver](https://neilkakkar.com/ai-made-me-braver.html) by Neil Kakkar
 
-There is a DOCX to DOCX converter, wait what? One is Google Docs DOCX, and another is my DOCX.
+  There is a DOCX to DOCX converter, wait what? One is Google Docs DOCX, and another is my DOCX.
 
-I like this quote:
+  I like this quote:
 
-> Looking back, being productive is nice. But imo feeling braver matters more.
+  > Looking back, being productive is nice. But imo feeling braver matters more.
 
-### [How I get things done](https://mxstbr.com/notes/getting-things-done) - Max Stoiber
+- [How I get things done](https://mxstbr.com/notes/getting-things-done) by Max Stoiber
 
-RACI vs ARCI & DRI.
+  RACI vs ARCI & DRI.
 
-### [The AI Productivity Gap](https://bjorg.bjornroche.com/management/ai-productivity-gap/) - Bjorn Roche
+- [The AI Productivity Gap](https://bjorg.bjornroche.com/management/ai-productivity-gap/) by Bjorn Roche
 
-Love multiple takes in this one.
+  Love multiple takes in this one.
 
-I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts.
+  I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts.
 
-> Using AI to make your work easier while making other people's job harder
+  > Using AI to make your work easier while making other people's job harder
 
-I can relate to this. As we use more and more of AI in a team setting, I think we need to be mindful and compassionate towards our colleagues.
+  I can relate to this. As we use more and more of AI in a team setting, I think we need to be mindful and compassionate towards our colleagues.
 
-### [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon) - Tim Bray
+- [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon) by Tim Bray
 
-Rekindled my interest in Mastodon and to get serious about it.
+  Rekindled my interest in Mastodon and to get serious about it.
 
-I have been using all the others (X, bsky) but stopped using Mastodon, mostly I think I was confused to what is the place I want to use for short form blogging.
+  I have been using all the others (X, bsky) but stopped using Mastodon, mostly I think I was confused to what is the place I want to use for short form blogging.
 
-Based on this blog post and my own experiences in the past few months, I clearly need to try Mastodon now.
+  Based on this blog post and my own experiences in the past few months, I clearly need to try Mastodon now.
 
-I spent much time exploring Mastodon. Still not so clear with it. e.g. which server?
+  I spent much time exploring Mastodon. Still not so clear with it. e.g. which server?
 
-### [Generated and suppressed demand](https://lethain.com/generated-demand/) - Will Larson
+- [Generated and suppressed demand](https://lethain.com/generated-demand/) by Will Larson
 
-TK - link Will Larson's "reading notes" OG post.
+  TK - link Will Larson's "reading notes" OG post.
 
-Suppressed demand is the idea of incoming work that isn't incoming, because teams stop asking you for help.
+  Suppressed demand is the idea of incoming work that isn't incoming, because teams stop asking you for help.
 
-Generated demand is when an increasingly effective team's progress is noticed and previously suppressed demand is converted into actual demand.
+  Generated demand is when an increasingly effective team's progress is noticed and previously suppressed demand is converted into actual demand.
 
-I haven't fully internalised the concepts in this post.
+  I haven't fully internalised the concepts in this post.
 
-### [The Productivity Mirage](https://frantic.im/mirage/) - Alex Kotliarskyi
+- [The Productivity Mirage](https://frantic.im/mirage/) by Alex Kotliarskyi
 
-Beautiful short memoir. Reminds me of what is important.
+  Beautiful short memoir. Reminds me of what is important.
 
-### [Product for Engineers is now build mode](https://newsletter.posthog.com/p/product-for-engineers-is-now-build) - Ian Vanagas
+- [Product for Engineers is now build mode](https://newsletter.posthog.com/p/product-for-engineers-is-now-build) by Ian Vanagas
 
-Long time reader of this blog, so read this out of curiosity to know why and what they are doing by renaming their blog.
+  Long time reader of this blog, so read this out of curiosity to know why and what they are doing by renaming their blog.
 
-### [LLMs reward expertise](https://seangoedecke.com/llms-reward-expertise/) - Sean Goedecke
+- [LLMs reward expertise](https://seangoedecke.com/llms-reward-expertise/) by Sean Goedecke
 
-> The most important skill in prompting is expertise in the domain you're prompting for
+  > The most important skill in prompting is expertise in the domain you're prompting for
 
-Don't follow what LLMs tell you. Ask critical questions that improve your understanding of the codebase/system. That way you can steer the LLM in a much better way.
+  Don't follow what LLMs tell you. Ask critical questions that improve your understanding of the codebase/system. That way you can steer the LLM in a much better way.
 
-### [The Cold Email](https://zachholman.com/posts/cold-email) - Zach Holman
+- [The Cold Email](https://zachholman.com/posts/cold-email) by Zach Holman
 
-My rate of sending cold emails is very low. But there was one time where a response to my cold email completely changed my world view. Maybe I need to try to send more.
+  My rate of sending cold emails is very low. But there was one time where a response to my cold email completely changed my world view. Maybe I need to try to send more.
 
-Oh, I have also gotten a few cold emails from people around the web and have genuinely enjoyed those conversations.
+  Oh, I have also gotten a few cold emails from people around the web and have genuinely enjoyed those conversations.
 
-### [5 Lessons at 50](http://muratbuffalo.blogspot.com/2026/06/5-lessons-at-50.html) - Murat Demirbas
+- [5 Lessons at 50](http://muratbuffalo.blogspot.com/2026/06/5-lessons-at-50.html) by Murat Demirbas
 
-My fav parts were 4 & 5. Because those are the ones that I have been coming to realise more and more in the recent times.
+  My fav parts were 4 & 5. Because those are the ones that I have been coming to realise more and more in the recent times.
 
-> The best strategy is to work on what you like, and what you find interesting and energizing, because curiosity, enthusiasm, and craft compounds
+  > The best strategy is to work on what you like, and what you find interesting and energizing, because curiosity, enthusiasm, and craft compounds
 
-### [What should a personal website be?](http://ratfactor.com/cards/personal-website) - Dave Gauer
+- [What should a personal website be?](http://ratfactor.com/cards/personal-website) by Dave Gauer
 
-It has to be whatever you want it to be.
+  It has to be whatever you want it to be.
 
-I really want to put out more of my thoughts on this site. I think that is what I want my website to be about.
+  I really want to put out more of my thoughts on this site. I think that is what I want my website to be about.
 
-### [The Religion of Speed](https://graybeard.ing/the-religion-of-speed/) - The Gospel According to Graybeard
+- [The Religion of Speed](https://graybeard.ing/the-religion-of-speed/) by The Gospel According to Graybeard
 
-Great article, especially relevant in the age of AI where software teams are expected to move with speed.
+  Great article, especially relevant in the age of AI where software teams are expected to move with speed.
 
-### [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html) - Murat Demirbas
+- [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html) by Murat Demirbas
 
-I am on the internet for gold mines like this.
+  I am on the internet for gold mines like this.

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -12,15 +12,15 @@ But for now, here is what I read in the week of 27 to 31 July 2026.
 
 ## Blogs
 
-- [AI Made Me Braver](https://neilkakkar.com/ai-made-me-braver.html) by Neil Kakkar
+- [AI Made Me Braver](https://neilkakkar.com/ai-made-me-braver.html)
 
   There is a DOCX to DOCX converter, wait what?
 
-- [How I get things done](https://mxstbr.com/notes/getting-things-done) by Max Stoiber
+- [How I get things done](https://mxstbr.com/notes/getting-things-done)
 
   I have come across RACI/ARCI & DRI at work before. I still feel like it is "too much theory" but the author gets to the practicality of it i.e. "Assign one accountable owner" is a distillation that I like to remember from this post.
 
-- [The AI Productivity Gap](https://bjorg.bjornroche.com/management/ai-productivity-gap/) by Bjorn Roche
+- [The AI Productivity Gap](https://bjorg.bjornroche.com/management/ai-productivity-gap/)
 
   Love multiple takes in this one. I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts.
 
@@ -28,11 +28,11 @@ But for now, here is what I read in the week of 27 to 31 July 2026.
 
   I can relate to this. As we use more and more of AI in a team setting, I think we need to be mindful and compassionate towards our colleagues.
 
-- [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon) by Tim Bray
+- [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon)
 
   Rekindled my interest in Mastodon. I have been using all the others (X, bsky) but stopped using Mastodon, mostly I think I was confused to what is the place I want to use for short form blogging.
 
-- [Generated and suppressed demand](https://lethain.com/generated-demand/) by Will Larson
+- [Generated and suppressed demand](https://lethain.com/generated-demand/)
 
   TK - link Will Larson's "reading notes" OG post.
 
@@ -42,43 +42,43 @@ But for now, here is what I read in the week of 27 to 31 July 2026.
 
   I haven't fully internalised the concepts in this post.
 
-- [The Productivity Mirage](https://frantic.im/mirage/) by Alex Kotliarskyi
+- [The Productivity Mirage](https://frantic.im/mirage/)
 
   Beautiful short memoir. Reminds me of what is important.
 
-- [Product for Engineers is now build mode](https://newsletter.posthog.com/p/product-for-engineers-is-now-build) by Ian Vanagas
+- [Product for Engineers is now build mode](https://newsletter.posthog.com/p/product-for-engineers-is-now-build)
 
   Long time reader of this blog, so read this out of curiosity to know why and what they are doing by renaming their blog.
 
-- [LLMs reward expertise](https://seangoedecke.com/llms-reward-expertise/) by Sean Goedecke
+- [LLMs reward expertise](https://seangoedecke.com/llms-reward-expertise/)
 
   > The most important skill in prompting is expertise in the domain you're prompting for
 
   Don't follow what LLMs tell you. Ask critical questions that improve your understanding of the codebase/system. That way you can steer the LLM in a much better way.
 
-- [The Cold Email](https://zachholman.com/posts/cold-email) by Zach Holman
+- [The Cold Email](https://zachholman.com/posts/cold-email)
 
   My rate of sending cold emails is very low. But there was one time where a response to my cold email completely changed my world view. Maybe I need to try to send more.
 
   Oh, I have also gotten a few cold emails from people around the web and have genuinely enjoyed those conversations.
 
-- [5 Lessons at 50](http://muratbuffalo.blogspot.com/2026/06/5-lessons-at-50.html) by Murat Demirbas
+- [5 Lessons at 50](http://muratbuffalo.blogspot.com/2026/06/5-lessons-at-50.html)
 
   My fav parts were 4 & 5. Because those are the ones that I have been coming to realise more and more in the recent times.
 
   > The best strategy is to work on what you like, and what you find interesting and energizing, because curiosity, enthusiasm, and craft compounds
 
-- [What should a personal website be?](http://ratfactor.com/cards/personal-website) by Dave Gauer
+- [What should a personal website be?](http://ratfactor.com/cards/personal-website)
 
   It has to be whatever you want it to be.
 
   I really want to put out more of my thoughts on this site. I think that is what I want my website to be about.
 
-- [The Religion of Speed](https://graybeard.ing/the-religion-of-speed/) by The Gospel According to Graybeard
+- [The Religion of Speed](https://graybeard.ing/the-religion-of-speed/)
 
   Great article, especially relevant in the age of AI where software teams are expected to move with speed.
 
-- [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html) by Murat Demirbas
+- [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html)
 
   I am on the internet for gold mines like this.
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -30,21 +30,15 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
   > Using AI to make your work easier while making other people's job harder
 
-  My take: As we use AI more and more in a team setting, we need to be very thoughtful and mindful in producing artifacts that doesn't overload our colleagues. Example: don't vibe code a 1000 line PR and send it to your teammate for a "code review".
+  My take: As we use AI more and more in a team setting, we need to be very thoughtful and mindful in producing artifacts that doesn't overload our colleagues.
 
 - [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon)
 
-  Rekindled my interest in Mastodon. I have been using all the others (X, bsky) but stopped using Mastodon. While doing my re-exploration of Mastodon, I met https://indieweb.org which made me double down on starting to write a blog post like the one you are reading now.
+  Rekindled my interest in Mastodon. While doing my re-exploration of Mastodon, I met https://indieweb.org which made me double down on starting to write a blog post like the one you are reading now.
 
 - [Generated and suppressed demand](https://lethain.com/generated-demand/)
 
-  TK - link Will Larson's "reading notes" OG post.
-
-  Suppressed demand is the idea of incoming work that isn't incoming, because teams stop asking you for help.
-
-  Generated demand is when an increasingly effective team's progress is noticed and previously suppressed demand is converted into actual demand.
-
-  I haven't fully internalised the concepts in this post.
+  I suggest reading [this post](https://lethain.com/durably-excellent-teams/) first - something that I have read in the past that gave me a good mental model of team performance. I haven't fully internalised the concepts in this new post though.
 
 - [The Productivity Mirage](https://frantic.im/mirage/)
 
@@ -62,7 +56,7 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
 - [The Cold Email](https://zachholman.com/posts/cold-email)
 
-  My rate of sending cold emails is very low. But there was one time where a response to my cold email completely changed my world view. Maybe I need to try to send more.
+  My rate of sending cold emails is very low. But there was one time where a response to my cold email completely changed my world view. Maybe I need to try to send more of these?
 
   Oh, I have also gotten a few cold emails from people around the web and have genuinely enjoyed those conversations.
 
@@ -74,13 +68,11 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
 - [What should a personal website be?](http://ratfactor.com/cards/personal-website)
 
-  It has to be whatever you want it to be.
-
-  I really want to put out more of my thoughts on this site. I think that is what I want my website to be about.
+  Spoiler: It has to be whatever you want it to be.
 
 - [The Religion of Speed](https://graybeard.ing/the-religion-of-speed/)
 
-  Great article, especially relevant in the age of AI where software teams are expected to move with speed.
+  Great article, especially relevant in the age of AI where software teams are expected to move with "speed".
 
 ## Books
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -1,0 +1,111 @@
+---
+title: Reading Log #1
+date: 2026-08-02 01:20:00
+tags: ["reading", "books", "blogging"]
+---
+
+I keep a daily log in a bullet journal. Two of the markers I use in it are `B:` for a book I read that day and `BL:` for a blog I read that day. When I flip back through a week, those are the lines I keep stopping at. So I am starting a reading log here to collect them, along with whatever I scribbled next to them at the time.
+
+My super power is reading. I should use it to my advantage.
+
+Most of the blogs below were read on paper. They usually exist with a `printed` tag in my Readwise, because I print them out and read them away from the screen.
+
+This is the week of 27 July to 31 July 2026.
+
+## Books
+
+### Rework
+
+Pages 1-32 on Sunday, 32-42 on Monday, 32-66 and then 67-82 on Tuesday.
+
+TK
+
+### Let Go
+
+Pages 77-115 on Tuesday. Great set of learning.
+
+TK - author/link for this one.
+
+## Blogs
+
+### [AI Made Me Braver](https://neilkakkar.com/ai-made-me-braver.html) - Neil Kakkar
+
+There is a DOCX to DOCX converter, wait what? One is Google Docs DOCX, and another is my DOCX.
+
+I like this quote:
+
+> Looking back, being productive is nice. But imo feeling braver matters more.
+
+### [How I get things done](https://mxstbr.com/notes/getting-things-done) - Max Stoiber
+
+RACI vs ARCI & DRI.
+
+### [The AI Productivity Gap](https://bjorg.bjornroche.com/management/ai-productivity-gap/) - Bjorn Roche
+
+Love multiple takes in this one.
+
+I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts.
+
+> Using AI to make your work easier while making other people's job harder
+
+I can relate to this. As we use more and more of AI in a team setting, I think we need to be mindful and compassionate towards our colleagues.
+
+### [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon) - Tim Bray
+
+Rekindled my interest in Mastodon and to get serious about it.
+
+I have been using all the others (X, bsky) but stopped using Mastodon, mostly I think I was confused to what is the place I want to use for short form blogging.
+
+Based on this blog post and my own experiences in the past few months, I clearly need to try Mastodon now.
+
+I spent much time exploring Mastodon. Still not so clear with it. e.g. which server?
+
+### [Generated and suppressed demand](https://lethain.com/generated-demand/) - Will Larson
+
+TK - link Will Larson's "reading notes" OG post.
+
+Suppressed demand is the idea of incoming work that isn't incoming, because teams stop asking you for help.
+
+Generated demand is when an increasingly effective team's progress is noticed and previously suppressed demand is converted into actual demand.
+
+I haven't fully internalised the concepts in this post.
+
+### [The Productivity Mirage](https://frantic.im/mirage/) - Alex Kotliarskyi
+
+Beautiful short memoir. Reminds me of what is important.
+
+### [Product for Engineers is now build mode](https://newsletter.posthog.com/p/product-for-engineers-is-now-build) - Ian Vanagas
+
+Long time reader of this blog, so read this out of curiosity to know why and what they are doing by renaming their blog.
+
+### [LLMs reward expertise](https://seangoedecke.com/llms-reward-expertise/) - Sean Goedecke
+
+> The most important skill in prompting is expertise in the domain you're prompting for
+
+Don't follow what LLMs tell you. Ask critical questions that improve your understanding of the codebase/system. That way you can steer the LLM in a much better way.
+
+### [The Cold Email](https://zachholman.com/posts/cold-email) - Zach Holman
+
+My rate of sending cold emails is very low. But there was one time where a response to my cold email completely changed my world view. Maybe I need to try to send more.
+
+Oh, I have also gotten a few cold emails from people around the web and have genuinely enjoyed those conversations.
+
+### [5 Lessons at 50](http://muratbuffalo.blogspot.com/2026/06/5-lessons-at-50.html) - Murat Demirbas
+
+My fav parts were 4 & 5. Because those are the ones that I have been coming to realise more and more in the recent times.
+
+> The best strategy is to work on what you like, and what you find interesting and energizing, because curiosity, enthusiasm, and craft compounds
+
+### [What should a personal website be?](http://ratfactor.com/cards/personal-website) - Dave Gauer
+
+It has to be whatever you want it to be.
+
+I really want to put out more of my thoughts on this site. I think that is what I want my website to be about.
+
+### [The Religion of Speed](https://graybeard.ing/the-religion-of-speed/) - The Gospel According to Graybeard
+
+Great article, especially relevant in the age of AI where software teams are expected to move with speed.
+
+### [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html) - Murat Demirbas
+
+I am on the internet for gold mines like this.

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -76,7 +76,7 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
 ## Books
 
-- **Rework** - pages 1-32 on Sunday, 32-42 on Monday, 32-66 and then 67-82 on Tuesday.
+- **Rework** - 82 pages
 
-- **Let Go** - pages 77-115 on Tuesday.
+- **Let Go** - 38 pages
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -4,25 +4,9 @@ date: 2026-08-02 01:20:00
 tags: ["reading", "books", "blogging"]
 ---
 
-I keep a daily log in a bullet journal. Two of the markers I use in it are `B:` for a book I read that day and `BL:` for a blog I read that day. When I flip back through a week, those are the lines I keep stopping at. So I am starting a reading log here to collect them, along with whatever I scribbled next to them at the time.
+I am trying something new. I used to use [Feedly](https://feedly.com/) for a long time for keeping up with my favorite blogs. But then I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time for the past 6 months. It is in a weird shape but definitely distracted myself from doing the real reading that I enjoy.
 
-My super power is reading. I should use it to my advantage.
-
-Most of the blogs below were read on paper. They usually exist with a `printed` tag in my Readwise, because I print them out and read them away from the screen.
-
-This is the week of 27 July to 31 July 2026.
-
-## Books
-
-- **Rework** - pages 1-32 on Sunday, 32-42 on Monday, 32-66 and then 67-82 on Tuesday.
-
-  TK
-
-- **Let Go** - pages 77-115 on Tuesday.
-
-  Great set of learning.
-
-  TK - author/link for this one.
+This is what I read in the week of 27 July to 31 July 2026.
 
 ## Blogs
 
@@ -107,3 +91,15 @@ This is the week of 27 July to 31 July 2026.
 - [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html) by Murat Demirbas
 
   I am on the internet for gold mines like this.
+
+## Books
+
+- **Rework** - pages 1-32 on Sunday, 32-42 on Monday, 32-66 and then 67-82 on Tuesday.
+
+  TK
+
+- **Let Go** - pages 77-115 on Tuesday.
+
+  Great set of learning.
+
+  TK - author/link for this one.

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -6,11 +6,15 @@ tags: ["reading", "books", "blogging"]
 
 I used to use [Feedly](https://feedly.com/) for a long time for keeping up with my favorite blogs. But then I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time for the past 6 months. It is in a weird shape but definitely distracted myself from doing the real reading that I enjoy.
 
-I have mashed up a new blog reading system for me but not based on my reader. Sadly it is not working out and I have to give it up. Maybe I will talk about the new system some other time after experimenting it for a bit.
+I have mashed up a new blog reading system for me but not based on my reader. Sadly it is not working out and I have to give up to get back to reading. Maybe I will talk about the new system some other time after experimenting with it for a bit.
 
-But for now, here is what I read in the week of 27 to 31 July 2026.
+But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 2026.
 
 ## Blogs
+
+- [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html)
+
+  I am on the internet for gold mines like this.
 
 - [AI Made Me Braver](https://neilkakkar.com/ai-made-me-braver.html)
 
@@ -18,19 +22,19 @@ But for now, here is what I read in the week of 27 to 31 July 2026.
 
 - [How I get things done](https://mxstbr.com/notes/getting-things-done)
 
-  I have come across RACI/ARCI & DRI at work before. I still feel like it is "too much theory" but the author gets to the practicality of it i.e. "Assign one accountable owner" is a distillation that I like to remember from this post.
+  I have come across RACI/ARCI & DRI at work before. I still feel like it is "too much theory" but the author gets to the practicality of it. "Assign one accountable owner" is a distillation that I like to remember from this post.
 
 - [The AI Productivity Gap](https://bjorg.bjornroche.com/management/ai-productivity-gap/)
 
-  Love multiple takes in this one. I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts.
+  Love multiple takes in this one. I do find myself in a similar position to the author on the topic of taking longer times to read AI written artifacts. There was this particular line that caught my attention:
 
   > Using AI to make your work easier while making other people's job harder
 
-  I can relate to this. As we use more and more of AI in a team setting, I think we need to be mindful and compassionate towards our colleagues.
+  My take: As we use AI more and more in a team setting, we need to be very thoughtful and mindful in producing artifacts that doesn't overload our colleagues. Example: don't vibe code a 1000 line PR and send it to your teammate for a "code review".
 
 - [Mastodon, The Only Good Choice](https://www.tbray.org/ongoing/When/202x/2026/07/05/Choose-Mastodon)
 
-  Rekindled my interest in Mastodon. I have been using all the others (X, bsky) but stopped using Mastodon, mostly I think I was confused to what is the place I want to use for short form blogging.
+  Rekindled my interest in Mastodon. I have been using all the others (X, bsky) but stopped using Mastodon. While doing my re-exploration of Mastodon, I met https://indieweb.org which made me double down on starting to write a blog post like the one you are reading now.
 
 - [Generated and suppressed demand](https://lethain.com/generated-demand/)
 
@@ -77,10 +81,6 @@ But for now, here is what I read in the week of 27 to 31 July 2026.
 - [The Religion of Speed](https://graybeard.ing/the-religion-of-speed/)
 
   Great article, especially relevant in the age of AI where software teams are expected to move with speed.
-
-- [Fool yourself](https://muratbuffalo.blogspot.com/2016/01/fool-yourself.html)
-
-  I am on the internet for gold mines like this.
 
 ## Books
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -78,13 +78,13 @@ But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 20
 
 - **Rework**
 
-  82 pages read
+  (read 82 pages)
 
   I haven't been taking notes for this one. Because it is the kind of a book that you could re-read instead of reading your notes.
 
 - **Let Go**
 
-  38 pages read
+  (read 38 pages)
 
   My wife picked up this book from the book store. I randomly started reading on a weekday night. I could visibly feel my "stress level" going down page after page. wow, books are weird - they can alter space, time, and mind.
 

--- a/source/_posts/reading-log-1.md
+++ b/source/_posts/reading-log-1.md
@@ -1,10 +1,10 @@
 ---
 title: "Reading Log #1"
 date: 2026-08-02 01:20:00
-tags: ["reading", "books", "blogs"]
+tags: ["reading", "books", "blogging"]
 ---
 
-I used to use [Feedly](https://feedly.com/) for a long time to keep up to date with my favorite blogs. Six months back, one fine day, I started working my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time. It went somewhere but my reading time went down. Sadly my reader didn't work out - it has hindered my reading and now I am out here resuming my reading.
+I used to use [Feedly](https://feedly.com/) for a long time to keep up to date with my favorite blogs. Six months back, one fine day, I started working on my own [RSS feed reader](https://github.com/scriptnull/rho-reader) in my free time. It went somewhere but my reading time went down. Sadly my reader didn't work out - it has hindered my reading and now I am out here resuming my reading.
 
 So I have mashed up a new blog reading system for me but not based on my reader. Maybe I will talk about the new system some other time after experimenting with it for a bit.
 


### PR DESCRIPTION
First post in a new Reading Log series — a weekly round-up of blogs and books, transcribed from my bullet journal (`B:` for books, `BL:` for blogs).

This one covers **27–31 July 2026**: 13 blog posts and 2 books.

Links for the blog entries were resolved from the `printed` tag in Readwise.

Merging publishes: the `[deploy]` prefix on the squashed commit message tells `.github/workflows/deploy.yml` to push the generated site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)