### PR TITLE
Add a reading-log skill

### DIFF
--- a/.claude/skills/reading-log/SKILL.md
+++ b/.claude/skills/reading-log/SKILL.md
@@ -99,10 +99,13 @@ tags: ["reading", "books", "blogging"]
 
 ### 4. Write the post
 
-Structure — intro prose with no heading above it, then blogs, then books:
+Structure — intro prose with no heading above it, then blogs, then books. The
+intro is his to write; you supply only the date line (see below):
 
 ```markdown
-<intro paragraphs>
+<he fills this in>
+
+But for now, here is what I read from <date range>.
 
 ## Blogs
 
@@ -145,14 +148,18 @@ is fine and necessary ("Great article, esp relevant..." → "Great article,
 especially relevant..."); rewriting is not. Anything he wrote inside quote
 marks was quoted from the article, so set it as a blockquote.
 
-The intro is the one part with no journal source, so you have to write it.
-It's a short personal lead-in — what's going on with his reading lately —
-ending with the date range, e.g. "here is what I read from 27<sup>th</sup> to
-31<sup>st</sup> July 2026." Don't explain the journal, the `B:`/`BL:` markers,
-or the printing habit; that's the machinery behind the post, not its subject.
-Once a few of these exist, follow the previous one's opening rather than
-inventing a new framing, and say plainly in your reply that the intro is
-yours to rewrite.
+**Don't write an intro.** The only line you generate above `## Blogs` is the
+date line:
+
+```markdown
+But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 2026.
+```
+
+The paragraphs above it are his — where his reading is at lately, what he's
+been building, why he's writing this one. None of that is in the journal, so
+anything you put there is invention he has to read and then delete, which
+costs him more than a blank would. Leave the space empty, and say in your
+reply that the intro is his to add.
 
 ### 5. Preview it
 
@@ -178,7 +185,7 @@ The post is a draft, not a delivery, so end with what he needs to decide:
 - Anything you read as ambiguous handwriting, with your best guess named
 - Any `B:` or `BL:` line you couldn't resolve to a title or a link
 - Larger grammar or flow edits you did **not** apply, as before/after pairs
-- The fact that the intro is yours
+- That the intro is still his to write — you left it blank
 
 Keep the report to those items. Lines outside `B:` and `BL:` don't belong in
 your reply any more than they belong in the post.

--- a/.claude/skills/reading-log/SKILL.md
+++ b/.claude/skills/reading-log/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: reading-log
+description: Draft a numbered "Reading Log #N" post for vishnubharathi.codes from photos of bullet journal pages, resolving blog links from Readwise. Use whenever the author shares pictures/scans of their daily log or journal spread and wants a reading log, a reading roundup, or a post about what they read this week — and also when they just say "reading log", "reading log #3", "here are my journal entries for the week", or hand over notebook photos with `B:` and `BL:` entries in them. Handles the image OCR prep, the Readwise link lookup, the Hexo front matter, and the no-deploy commit convention.
+---
+
+# Reading Log
+
+Turn photos of Vishnu's (`scriptnull`) bullet journal into a numbered reading
+log post in this repo. The journal is the source of truth; your job is to
+transcribe it faithfully, attach real links, and get out of the way.
+
+The [`new-blog-post`](../new-blog-post/SKILL.md) skill governs voice, TK
+markers, and the commit convention — all of it applies here. Read it if you
+haven't. This skill covers what's specific to reading logs.
+
+## What you're looking for
+
+Each journal page is a `DAILY LOG` with a date header like `29.7.WE`. Lines
+carry short prefixes. Exactly two of them are in scope:
+
+| Prefix | Meaning |
+|---|---|
+| `B:` | A book, usually with a page range |
+| `BL:` | A blog post |
+
+Everything nested under a `B:` or `BL:` line — the dashes, the quoted
+passages, the half-finished thoughts — is his commentary on that item, and it
+is the actual content of the post. The titles are just scaffolding.
+
+**Every other line on the page is a no-op.** Don't transcribe it, don't
+summarise it, don't ask about it, and don't describe what those lines are —
+here, in your reply, or anywhere else. This is a private journal that happens
+to contain two publishable lines a day; treat the rest as if it weren't
+there. If a line is ambiguous, it's out.
+
+## Workflow
+
+### 1. Read the pages
+
+Phone photos of a notebook come in rotated and too low-resolution to read at
+full-page scale. Prep them first:
+
+```sh
+python3 .claude/skills/reading-log/scripts/prep_journal_images.py \
+  <image paths> --out <scratchpad>/journal
+```
+
+Then read the crops. Two or three at a time in parallel is fine. If the text
+comes out sideways or upside down, rerun with `--rotate 0` or `--rotate 90`.
+If a specific line stays ambiguous, crop and upscale just that line rather
+than squinting — a wrong book title is worse than an extra tool call.
+
+Sort the pages into date order yourself, from the date headers. Upload order
+and filename order are both unreliable.
+
+### 2. Resolve the blog links from Readwise
+
+He reads blogs on paper, so anything with a `BL:` marker was printed, which
+means it carries the `printed` tag in Readwise. That tag is the lookup table:
+
+```
+reader_list_documents(tag=["printed"], limit=50,
+  response_fields=["title", "url", "source_url", "author", "site_name", "created_at"])
+```
+
+Match journal titles against it and use `source_url` — the original article —
+not `url`, which is the Readwise reader link. The `author` field is often an
+RSS feed name (`seangoedecke.com RSS feed`, `Murat (noreply@blogger.com)`);
+clean it up to the human's name where you know it, and fall back to the site
+name when you don't.
+
+Handwritten titles drift from the real ones ("5 lessons at 60" for *5 Lessons
+at 50*), so trust the Readwise title over your reading of the page. If an
+entry has no match, leave the title unlinked with a `TK` next to it rather
+than guessing a URL — a wrong link is the one error a reader will notice.
+
+Don't try to fetch the articles themselves to fill in context. Several of
+these sites block automated fetches, and the notes should be his words about
+the piece, not a summary you generated.
+
+### 3. Work out the number
+
+```sh
+ls source/_posts/reading-log-*.md
+```
+
+The next one continues the sequence. File is `source/_posts/reading-log-N.md`,
+permalink `/blog/reading-log-N/`.
+
+**Quote the title in the front matter.** `title: Reading Log #1` parses as
+`Reading Log` — YAML treats the ` #` as the start of a comment and silently
+drops the number, which you won't notice until the post is live with the
+wrong name.
+
+```yaml
+title: "Reading Log #1"
+tags: ["reading", "books", "blogging"]
+```
+
+### 4. Write the post
+
+Structure — intro prose with no heading above it, then blogs, then books:
+
+```markdown
+<intro paragraphs>
+
+## Blogs
+
+- [Title](source_url)
+
+  <his notes>
+
+  > <anything he quoted from the piece>
+
+## Books
+
+- **Title**
+
+  (read N pages)
+
+  <his notes>
+```
+
+Blogs come before books: there are usually a dozen of them to two books, and
+they're the part he has the most to say about.
+
+Entries are **bullet points, not headings** — the title and link sit on the
+point, the notes are indented beneath it. This is a log; a list reads like
+one, and a page of `###` headings for thirteen short entries does not. No
+author bylines on the points; the link carries that.
+
+For books, give the total pages read across the week, not the per-day ranges.
+He tracks ranges in the journal to know where to resume, not to publish.
+
+**Keep the notes tight — roughly a short paragraph per entry.** The journal
+holds several fragmentary lines per item, and dumping all of them in makes
+the draft baggy in a way that takes him longer to cut than to write. Merge
+the fragments into one or two sentences that carry the point and drop the
+throwaways. He will expand the entries he cares about with things the journal
+never held — a link to a related post, what happened when he tried the idea —
+so a lean, accurate draft is more useful to him than an exhaustive one.
+
+Keep his sentences where you keep them. Expanding shorthand into a sentence
+is fine and necessary ("Great article, esp relevant..." → "Great article,
+especially relevant..."); rewriting is not. Anything he wrote inside quote
+marks was quoted from the article, so set it as a blockquote.
+
+The intro is the one part with no journal source, so you have to write it.
+It's a short personal lead-in — what's going on with his reading lately —
+ending with the date range, e.g. "here is what I read from 27<sup>th</sup> to
+31<sup>st</sup> July 2026." Don't explain the journal, the `B:`/`BL:` markers,
+or the printing habit; that's the machinery behind the post, not its subject.
+Once a few of these exist, follow the previous one's opening rather than
+inventing a new framing, and say plainly in your reply that the intro is
+yours to rewrite.
+
+### 5. Preview it
+
+Build a single-page HTML preview and publish it as an artifact so he can read
+the post as a page instead of as a diff. Worth including: the resolved front
+matter, a count of books and blogs, every entry rendered, and the `TK` markers
+visibly flagged so the remaining work is obvious at a glance. Load the
+`artifact-design` skill before writing it.
+
+Redeploy the same file path when he asks for changes so the link stays stable.
+
+### 6. Commit
+
+Commit message must **not** start with `[deploy]` — CI builds but withholds
+publishing for unprefixed commits, which is what you want for a draft he
+hasn't approved yet. Push to the current branch. Don't touch `docs/`.
+
+## Report back
+
+The post is a draft, not a delivery, so end with what he needs to decide:
+
+- Every `TK` you left, and why
+- Anything you read as ambiguous handwriting, with your best guess named
+- Any `B:` or `BL:` line you couldn't resolve to a title or a link
+- Larger grammar or flow edits you did **not** apply, as before/after pairs
+- The fact that the intro is yours
+
+Keep the report to those items. Lines outside `B:` and `BL:` don't belong in
+your reply any more than they belong in the post.
+
+Journal page ranges routinely overlap or contradict each other across days —
+he is writing quickly, not keeping ledgers. Transcribe what's on the page and
+ask, rather than quietly reconciling the numbers.

--- a/.claude/skills/reading-log/scripts/prep_journal_images.py
+++ b/.claude/skills/reading-log/scripts/prep_journal_images.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Prepare photos of bullet journal pages for reading.
+
+Phone photos of a notebook are almost always rotated, and at full-page scale
+the handwriting is too small to read reliably even at 4096px — the Read tool
+downsamples to ~2000px wide, which is below the threshold where cursive stays
+legible. Rotating upright and slicing each page into horizontal bands fixes
+both problems at once: each band gets the full display budget, so the text
+lands at roughly 2-3x the effective resolution.
+
+Usage:
+    python3 prep_journal_images.py IMG [IMG ...] --out DIR [--rotate -90] [--slices 3]
+
+Prints a manifest of the crops it wrote, in page order, so you know what to
+read and in which sequence.
+"""
+
+import argparse
+import os
+import sys
+
+try:
+    from PIL import Image
+except ImportError:
+    sys.exit(
+        "Pillow is not installed. Run:  pip install pillow\n"
+        "(or: pip3 install --break-system-packages pillow)"
+    )
+
+
+def prep(path, out_dir, rotate, slices):
+    im = Image.open(path)
+    if rotate:
+        im = im.rotate(rotate, expand=True)
+    w, h = im.size
+    stem = os.path.splitext(os.path.basename(path))[0][:12]
+    written = []
+    for i in range(slices):
+        top = h * i // slices
+        bottom = h * (i + 1) // slices
+        # Overlap each band slightly so a line straddling a cut is never lost.
+        pad = (bottom - top) // 25
+        band = im.crop((0, max(0, top - pad), w, min(h, bottom + pad)))
+        dest = os.path.join(out_dir, f"{stem}_{i}.jpg")
+        band.save(dest, quality=95)
+        written.append(dest)
+    return written
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("images", nargs="+")
+    ap.add_argument("--out", required=True, help="output directory for crops")
+    ap.add_argument(
+        "--rotate",
+        type=int,
+        default=-90,
+        help="degrees counter-clockwise; -90 suits the usual landscape phone "
+        "photo of a portrait page. Use 0 if the photo is already upright, "
+        "90 if it comes out upside down.",
+    )
+    ap.add_argument("--slices", type=int, default=3, help="horizontal bands per page")
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    for path in args.images:
+        for dest in prep(path, args.out, args.rotate, args.slices):
+            print(dest)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Captures the workflow behind [Reading Log #1](https://github.com/scriptnull/vishnubharathi.codes/pull/59) as a project skill, so the next one is less manual. The post itself already landed in #59 — this is skill files only.

## Contents

**`.claude/skills/reading-log/SKILL.md`** — reading the journal photos, resolving blog links from the `printed` tag in Readwise, the post structure (blogs before books, bullet points rather than headings, notes kept to a short paragraph), auto-numbering from the existing posts, and the unprefixed-commit convention.

**`.claude/skills/reading-log/scripts/prep_journal_images.py`** — rotates phone photos of the notebook upright and slices each page into overlapping bands. At full-page scale the handwriting downsamples below the point where it can be read reliably; the bands give each one the full display budget.

## One thing worth knowing

The skill records that the front matter title has to be quoted:

```yaml
title: "Reading Log #1"
```

Unquoted, YAML reads the ` #` as the start of a comment and the title silently becomes `Reading Log`.

## Publishing

No content changes here, and the commits are not `[deploy]`-prefixed, so nothing publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRspxvyTLYDsTHrKKbiCYD