### PR TITLE
Reading Log #2

### DIFF
--- a/.claude/skills/reading-log/SKILL.md
+++ b/.claude/skills/reading-log/SKILL.md
@@ -105,7 +105,7 @@ intro is his to write; you supply only the date line (see below):
 ```markdown
 <he fills this in>
 
-But for now, here is what I read from <date range>.
+Here is what I read from <date range>.
 
 ## Blogs
 
@@ -152,7 +152,7 @@ marks was quoted from the article, so set it as a blockquote.
 date line:
 
 ```markdown
-But for now, here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 2026.
+Here is what I read from 27<sup>th</sup> to 31<sup>st</sup> July 2026.
 ```
 
 The paragraphs above it are his — where his reading is at lately, what he's

--- a/source/_posts/reading-log-2.md
+++ b/source/_posts/reading-log-2.md
@@ -8,9 +8,11 @@ Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 
 ## Blogs
 
-- [In defense of not understanding your codebase](https://seangoedecke.com/in-defense-of-not-understanding-your-codebase/)
+- [Never Enough](https://dark.ronacher.eu/2026/7/21/never-enough/)
 
-  "Theory of the program" is one important concept I learned from the article. I think having a common place book of programs might be good.
+  A short piece that might bring peace within. My fav lines:
+
+  > Maybe we need the misfits who know when to stop. Who leave a conversation unrecorded. Who play with their children without agents running in background. Who can admire another person's success without feeling diminished by it. Who find peace not by getting ahead, but by no longer needing to
 
 - [Blog about things you don't understand yet](https://seangoedecke.com/blog-about-things-you-dont-understand-yet/)
 
@@ -18,37 +20,33 @@ Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 
   > One thing you learn when you try to write poetry is that it is way easier to write to a restrictive structure than it is to simply "write what you feel"
 
-- [Avoid the trap of magical thinking](https://bjorg.bjornroche.com/management/magical-thinking/)
+- [The Shape of Things to Come - Part 1](https://yegge.ai/essays/the-shape-of-things-to-come/)
 
-  If you are into "how to run engineering teams", then don't miss this read.
+  > Harness need to be part of your application, chemically bonded in
 
-- [Never Enough](https://dark.ronacher.eu/2026/7/21/never-enough/)
+  This gave me an instant "we are in a Sci-Fi" moment. It reminded me of [this tweet](https://x.com/levelsio/status/2071162399864889705) from levelsio: install harness on a VM and do dev there. It is the simplest way to taste the future mentioned in the post. Anyway, I have started experimenting things out for myself.
 
-  A short piece that might bring peace within. My fav lines:
+- [The Shape of Things to Come - Part 2](https://yegge.ai/essays/model-welfare/)
 
-  > Maybe we need the misfits who know when to stop. Who leave a conversation unrecorded. Who play with their children without agents running in background. Who can admire another person's success without feeling diminished by it. Who find peace not by getting ahead, but by no longer needing to
+  The author says that models have actual feelings and that we need to treat agents like real people. In return, they will spend less tokens, make smarter decisions, etc.
+
+  My extreme take after reading both the parts of the blog post: There might be a future, where every project will start with creating a new harness instead of a new git repo.
 
 - [Book Recommendations and Notes](https://www.ssp.sh/books/)
 
   Nice roundup of books. Took a few and kept them in my future buying list.
 
-- [The Shape of Things to Come - Part 1](https://yegge.ai/essays/the-shape-of-things-to-come/)
+- [In defense of not understanding your codebase](https://seangoedecke.com/in-defense-of-not-understanding-your-codebase/)
 
-  > Harness need to be part of your application, chemically bonded in
+  "Theory of the program" is one important concept I learned from the article. I have been thinking of starting a commonplace notebook for work.
 
-  Wow, this gave me an instant "we are in a Sci-Fi" moment. Levelsio tweeted to install harness on a VM and do dev there. The idea is to have one agent (a remote session) with Claude Code that you talk with, and many more Claude Code / codex agents running as systems. Name them - eg. Claudes belong to the Naruto universe and codexs belong to some other universe.
+- [Avoid the trap of magical thinking](https://bjorg.bjornroche.com/management/magical-thinking/)
 
-- [The Shape of Things to Come - Part 2](https://yegge.ai/essays/model-welfare/)
+  If you are into "how to run engineering teams", then don't miss this read.
 
-  Steve says models have actual feelings. Takeaway: treat agents like real people. They will spend less tokens, make smarter decisions, etc. This is great. I think every project will start with creating a new harness instead of a new git repo.
+- [What have note-taking PKMs accomplished, really?](https://brennan.day/what-have-note-taking-pkms-accomplished-really/) and [Note-Taking and Personal Knowledge Management](https://unattributed.cc/note-taking-and-personal-knowledge-management)
 
-- [What have note-taking PKMs accomplished, really?](https://brennan.day/what-have-note-taking-pkms-accomplished-really/)
-
-  > Systems work when they're subordinate to real work, not when the system itself is the project
-
-- [Note-Taking and Personal Knowledge Management](https://unattributed.cc/note-taking-and-personal-knowledge-management)
-
-  It is a response to the previous post mentioned.
+  I am interested in PKMs, so I read them out of curiosity. But I would not recommend them for general audience.
 
 - [Don't be a meat proxy](https://gruhn.me/blog/2026-08-03/)
 
@@ -70,7 +68,7 @@ Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 
 - [Pi, Minimal and Performant](https://earendil.com/posts/pi-autoresearch-and-databricks/)
 
-  Going to give Pi a try one more time. Maybe third time is the charm?
+  I want to give Pi a try one more time. Maybe third time is the charm?
 
 - [What I Want to Tell You About Orbs](https://ampcode.com/notes/what-i-want-to-tell-you-about-orbs)
 
@@ -92,6 +90,8 @@ Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 
   (read 10 pages)
 
+  I am trying to get into fiction and started stocking up some books in my shelf. This is one such book. Heard mixed feelings from different people about the book/author. Some like it, and some hate it. I don't know which band I will be part of.
+
 - **Rework**
 
   (read 5 pages)
@@ -99,3 +99,5 @@ Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 - **The Inner Game of Tennis**
 
   (read 30 pages)
+
+  This might be the most important book I've read this year so far. My gut says so.

--- a/source/_posts/reading-log-2.md
+++ b/source/_posts/reading-log-2.md
@@ -1,0 +1,103 @@
+---
+title: "Reading Log #2"
+date: 2026-08-08 23:10:00
+tags: ["reading", "books", "blogging"]
+---
+
+TK intro
+
+But for now, here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
+
+## Blogs
+
+- [In defense of not understanding your codebase](https://seangoedecke.com/in-defense-of-not-understanding-your-codebase/)
+
+  "Theory of the program" is one important concept I learned from the article. I think having a common place book of programs might be good.
+
+- [Blog about things you don't understand yet](https://seangoedecke.com/blog-about-things-you-dont-understand-yet/)
+
+  Great tips for aspiring bloggers. My learning: you should be learning something while writing a blog post. The signs of learning are that you change your mind a lot as you write, and that your first draft's conclusion is much better than your introduction - so you end up rewriting the introduction.
+
+  > One thing you learn when you try to write poetry is that it is way easier to write to a restrictive structure than it is to simply "write what you feel"
+
+- [Avoid the trap of magical thinking](https://bjorg.bjornroche.com/management/magical-thinking/)
+
+  If you are into "how to run engineering teams", then don't miss this read.
+
+- [Never Enough](https://dark.ronacher.eu/2026/7/21/never-enough/)
+
+  A short piece that might bring peace within. My fav lines:
+
+  > Maybe we need the misfits who know when to stop. Who leave a conversation unrecorded. Who play with their children without agents running in background. Who can admire another person's success without feeling diminished by it. Who find peace not by getting ahead, but by no longer needing to
+
+- [Book Recommendations and Notes](https://www.ssp.sh/books/)
+
+  Nice roundup of books. Took a few and kept them in my future buying list.
+
+- [The Shape of Things to Come - Part 1](https://yegge.ai/essays/the-shape-of-things-to-come/)
+
+  > Harness need to be part of your application, chemically bonded in
+
+  Wow, this gave me an instant "we are in a Sci-Fi" moment. Levelsio tweeted to install harness on a VM and do dev there. The idea is to have one agent (a remote session) with Claude Code that you talk with, and many more Claude Code / codex agents running as systems. Name them - eg. Claudes belong to the Naruto universe and codexs belong to some other universe.
+
+- [The Shape of Things to Come - Part 2](https://yegge.ai/essays/model-welfare/)
+
+  Steve says models have actual feelings. Takeaway: treat agents like real people. They will spend less tokens, make smarter decisions, etc. This is great. I think every project will start with creating a new harness instead of a new git repo.
+
+- [What have note-taking PKMs accomplished, really?](https://brennan.day/what-have-note-taking-pkms-accomplished-really/)
+
+  > Systems work when they're subordinate to real work, not when the system itself is the project
+
+- [Note-Taking and Personal Knowledge Management](https://unattributed.cc/note-taking-and-personal-knowledge-management)
+
+  It is a response to the previous post mentioned.
+
+- [Don't be a meat proxy](https://gruhn.me/blog/2026-08-03/)
+
+  Nice articulation of the idea. This is what I meant in the previous reading log as being empathetic towards colleagues. Short and to the point.
+
+- [88 Prompts for Long Term Thinking](https://kk.org/thetechnium/88-prompts-for-long-term-thinking/)
+
+  Plan vs perspective: a plan is a type of answer, a perspective is a type of question.
+
+  > Individually we are better off with expanding possibilities for everyone
+
+  > Focus not on the outcomes, but on the processes that produce outcomes
+
+  > Every idea about the future is a prediction. Nearly all predictions are wrong. But some are useful
+
+  > Our optimism about the future lies not in how small we think our current problems are but how large we believe our capacities for improvement are
+
+  > To understand the far future, we must understand the deep past.
+
+- [Pi, Minimal and Performant](https://earendil.com/posts/pi-autoresearch-and-databricks/)
+
+  Going to give Pi a try one more time. Maybe third time is the charm?
+
+- [What I Want to Tell You About Orbs](https://ampcode.com/notes/what-i-want-to-tell-you-about-orbs)
+
+  This is from the folks at amp. I used to use ampcode but they moved on and I think their new thing is orbs. Let me see if I get a chance to explore them sometime.
+
+- [You Should Write An Agent](https://fly.io/blog/everyone-write-an-agent/)
+
+  The Pi post inspired me to look more closely into the internals of agents, and so I picked this up and read it.
+
+## Books
+
+- **Let Go**
+
+  (read 21 pages)
+
+  Everyday is not the same. Accept that. Nature is the biggest evidence of this - there is a slight difference in everything that happens everyday. So it is completely okay to not force everyday to look the same, and to make little changes everyday.
+
+- **Norwegian Wood**
+
+  (read 10 pages)
+
+- **Rework**
+
+  (read 5 pages)
+
+- **The Inner Game of Tennis**
+
+  (read 30 pages)

--- a/source/_posts/reading-log-2.md
+++ b/source/_posts/reading-log-2.md
@@ -38,7 +38,7 @@ Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 
 - [In defense of not understanding your codebase](https://seangoedecke.com/in-defense-of-not-understanding-your-codebase/)
 
-  "Theory of the program" is one important concept I learned from the article. I have been thinking of starting a commonplace notebook for work.
+  "Theory of the program" is one important concept I learned from the article. I have been thinking of starting a commonplace notebook to jot down the theory of the programs and started one after reading this post. Let us see where it goes.
 
 - [Avoid the trap of magical thinking](https://bjorg.bjornroche.com/management/magical-thinking/)
 
@@ -46,15 +46,15 @@ Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 
 - [What have note-taking PKMs accomplished, really?](https://brennan.day/what-have-note-taking-pkms-accomplished-really/) and [Note-Taking and Personal Knowledge Management](https://unattributed.cc/note-taking-and-personal-knowledge-management)
 
-  I am interested in PKMs, so I read them out of curiosity. But I would not recommend them for general audience.
+  I am interested in PKMs, so I read them out of curiosity. But I would not recommend these posts for general audience.
 
 - [Don't be a meat proxy](https://gruhn.me/blog/2026-08-03/)
 
-  Nice articulation of the idea. This is what I meant in the previous reading log as being empathetic towards colleagues. Short and to the point.
+  Nice articulation of the idea. This is what I meant in the previous reading log as being empathetic towards colleagues. This post is short and to the point.
 
 - [88 Prompts for Long Term Thinking](https://kk.org/thetechnium/88-prompts-for-long-term-thinking/)
 
-  Plan vs perspective: a plan is a type of answer, a perspective is a type of question.
+  The prompts that I really loved:
 
   > Individually we are better off with expanding possibilities for everyone
 

--- a/source/_posts/reading-log-2.md
+++ b/source/_posts/reading-log-2.md
@@ -4,9 +4,7 @@ date: 2026-08-08 23:10:00
 tags: ["reading", "books", "blogging"]
 ---
 
-TK intro
-
-But for now, here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
+Here is what I read from 1<sup>st</sup> to 7<sup>th</sup> August 2026.
 
 ## Blogs
 


### PR DESCRIPTION
Reading log for 1–7 August 2026, transcribed from the daily log: 14 blog posts and 4 books (66 pages).

Blog links were resolved against the `printed` tag in Readwise — every entry points at the original article, none unresolved.

Also updates the `reading-log` skill template to drop the "But for now" opener, matching how this post starts.

**Not deployed.** No commit here is `[deploy]`-prefixed, so CI builds the site but withholds the push. Publishing needs a `[deploy]` commit on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)